### PR TITLE
Formatting update

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,5 +13,5 @@ jobs:
     - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.11.0
       with:
-        clang-format-version: '16'
+        clang-format-version: '17'
         check-path: 'src'


### PR DESCRIPTION
Since the generated formatting file currently has some options, that are nonexistent in clang version 16, I downgraded the version in the workflow and also removed the options in question.