### PR TITLE
Makefile quickfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ fclean: clean
 .PHONY: re
 re: fclean all
 
-HEADERS = $(wildcard src/**.hpp)
+HEADERS = $(wildcard src/*.hpp) $(wildcard src/*/*.hpp)
 
 test/testmain.cpp: $(HEADERS)
 	@echo $^


### PR DESCRIPTION
Test generation failed because the wildcard apparently doesn't recursively match all `.hpp` files.