### PR TITLE
Fixed error page crash

### DIFF
--- a/src/task/ReceiveRequestTask.cpp
+++ b/src/task/ReceiveRequestTask.cpp
@@ -156,7 +156,7 @@ void ReceiveRequestTask::run()
         WARN(error.what());
 
         Response* response;
-        if (error_path.has_value())
+        if (error_path.has_value() && error_path.value().type() == Path::REGULAR)
             response = new ErrorResponse(error_path.value(), error.status());
         else
             response = new ErrorResponse(_server.config().error_str(), error.status());


### PR DESCRIPTION
The server crashed when an error response was attempted to be constructed from a nonexistent path. IE if an error page file that was defined was deleted during initialization.

The fix is to simply have a check for if the type of the error page path is regular, which means the file exists.

Closes #40 