### PR TITLE
Tini: Fix iterator overflow

### DIFF
--- a/src/config/TiniValidator.cpp
+++ b/src/config/TiniValidator.cpp
@@ -30,7 +30,7 @@ int TiniValidator::validateContext(std::string ctx, int row)
                 if (a == _next_state)
                 {
                     good = 1;
-                    break ;
+                    break;
                 }
             }
             if (good != 1)


### PR DESCRIPTION
As was stated in the previous issue, Tini was underflowing by one byte in a string because of poor iterator handling. The quickfix build now doesn't get any errors from `fsanitize=address` and basic fuzzing with `/dev/urandom`.

Closes #43 